### PR TITLE
Encoding to ISO-8859-15 for Festival

### DIFF
--- a/tts.py
+++ b/tts.py
@@ -502,7 +502,7 @@ class FestivalTTS(TTSBase):
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
             )
-            await proc.communicate(input=text.encode())
+            await proc.communicate(input=text.encode(encoding="iso-8859-15"))
 
             wav_file.seek(0)
             return wav_file.read()


### PR DESCRIPTION
Because Festival does not support UTF-8[1], it requires an explicit encode to something else.

AFAICT, **ca** and **es** are fixed by using ISO-8859-15. English doesn't really care on the encoding. I have no idea what happens with Czech (which is the other supported language for Festival).

In my tests, this change is enough to solve #3.

[1] https://www.web3.lu/character-encoding-for-festival-tts-files/