### PR TITLE
Added caching of speech

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN apt-get update && \
         festvox-us-slt-hts \
         festvox-ru \
         festvox-suopuhe-lj \
-        festvox-suopuhe-mv
+        festvox-suopuhe-mv \
+	supervisor
 
 # Install prebuilt nanoTTS
 RUN wget -O - --no-check-certificate \
@@ -69,9 +70,10 @@ COPY img/ /app/img/
 COPY css/ /app/css/
 COPY app.py tts.py swagger.yaml /app/
 COPY templates/index.html /app/templates/
+COPY manage_tts_cache.sh run.sh /
 
 WORKDIR /app
 
 EXPOSE 5500
 
-ENTRYPOINT ["/app/.venv/bin/python3", "/app/app.py"]
+ENTRYPOINT ["/bin/bash", "/run.sh"]

--- a/manage_tts_cache.sh
+++ b/manage_tts_cache.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+cache="/data"
+maxCacheSize=50000000
+duSizeOpt="b"
+
+# For now, the cache size isn't configurable, so we don't need to worry about
+# this stuff....
+#case "$maxCacheSize" in
+#    *GB)
+#        duSizeOpt="BK"
+#        ;;
+#    *MB)
+#        duSizeOpt="BK"
+#        ;;
+#    *KB)
+#        duSizeOpt="BK"
+#        ;;
+#    [0-9]*)
+#        # It's all digits, assume it's the size in bytes
+#        ;;
+#    *)
+#        maxCacheSize=50000000
+#        ;;
+#esac
+maxCacheSize=${maxCacheSize/([^0-9]*)/}
+
+function manageCache() {
+    cacheSize=$(/usr/bin/du -s${duSizeOpt} "${cache}")
+    cacheSize=${cacheSize/[^0-9]*/}
+    while [ ${cacheSize} -gt ${maxCacheSize} ]
+    do
+        /bin/rm -f $(/bin/ls -tur "${cache}" | /usr/bin/head -n 1)
+        cacheSize=$(/usr/bin/du -s${duSizeOpt} "${cache}")
+        cacheSize=${cacheSize/([^0-9]*)/}
+    done
+}
+
+echo "READY"
+len=0
+read -a header
+for i in ${header[@]}
+do
+    if [[ ${i} == len:* ]]; then
+        len=${i/len:/}
+    fi
+done
+
+if [ "${len}" == "0" ]; then
+    exit 0
+fi
+
+read -N ${len} when && manageCache 
+if [ $? -eq 0 ]; then
+    echo "RESULT 2"
+    echo "OK"
+else
+    echo "RESULT 4"
+    echo "FAIL"
+fi
+exit 0
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+CONF_FILE="/etc/supervisord.conf"
+
+cat >"${CONF_FILE}" << _EOF
+[supervisord]
+nodaemon = true
+pidfile = /supervisord.pid
+user = root
+
+[program:app]
+command=/app/.venv/bin/python3 /app/app.py $*
+autostart=true
+autorestart=true
+
+[eventlistener:manage_tts_cache]
+command=/usr/bin/env bash /manage_tts_cache.sh
+autostart=true
+autorestart=true
+events=TICK_3600
+_EOF
+
+/bin/supervisord -c "${CONF_FILE}" &
+WAIT_PIDS=($!)
+
+function stop_container() {
+   kill -TERM "${WAIT_PIDS[@]}"
+   wait "${WAIT_PIDS[@]}"
+}
+
+trap "stop_container" SIGTERM SIGHUP
+
+wait "${WAIT_PIDS[@]}"


### PR DESCRIPTION
For me, speech generation takes a noticeable time, and is usually the same few dozen phrases.  Caching the output of the speech generator is extremely helpful for me, removing the delay between action and result.  I don't know if it would be useful generically or not.  Since I really think the cache size should be configurable, I'm marking this as a draft request; making it configurable can be done if adding this request is desirable.
 
Note: Generated speech will be cached in /data, you must make this path
available to your docker container.

Dockerfile changes:
Added supervisor to docker image
Added new scripts, manage_tts_cache.sh and run.sh
Changed ENTRYPOINT to run.sh

app.py changes:
Updated to check for cached speech in /data.  If it exists, it will be
returned and no new speech generated.  If it does not exist (or is
empty), then the speech is generated and saved to a file before it is
returned.  Note, too, that the cache files are named as the SHA256 hash
of the actual text, the name of the TTS engine, and the voice id.  This
means that if you request the same speech with different voices or TTS
engines, a cached result will not be used.  By using a SHA256 hash, we
also prevent exposure of the text in the cache.  If testing reveals
collisions in the SHA256 hash, dropping the TTS engine and voice id
would likely reduce collisions.

manage_tts_cache.sh:
The new manage_tts_cache.sh script is nearly identical to one I wrote
for a different project using snips.  It will delete cached speech if
the specified size is exceeded.  It gets invoked through supervisor once
an hour.  The size is hard-coded as 50000000 bytes.  This could be made
configurable.

run.sh:
The new run.sh sript is the new entrypoint for the container.  It
creates a configuration file for supervisor based on the command line
arguments (which will get passed to app.py) and runs supervisor.
Additionally, the script will wait, watching for SIGTERM and SIGKILL.
If it gets either, it will nicely terminate supervisor, which stops
app.py and manage_tts_cache.sh.

Discussion:
This should probably be modified to add some sort of configuration for
how long the data is cached.

Perhaps command-line arguments to docker could be used to configure the
size for manage_tts_cache.sh, but run.sh would need to recognize the
configuration option for manage_tts_cache.sh and pass it to
manage_tts_cache.sh while passing all other options to app.py.
Alternatively, manage_tts_cache.sh could be reworked in python, and
invoked regularly from app.py, which would eliminate the need for
run.sh and supervisor.