### PR TITLE
Add docker-compose examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+## OpenTTS Examples
+
+This folder contains examples to use when deploying OpenTTS, currently limited to [docker compose](https://docs.docker.com/compose/) examples.

--- a/examples/docker-compose-opentts-full-suite.yml
+++ b/examples/docker-compose-opentts-full-suite.yml
@@ -1,0 +1,16 @@
+version: '3.3'
+
+# from https://rhasspy.readthedocs.io/en/latest/text-to-speech/#opentts
+services:
+  opentts:
+    image: synesthesiam/opentts
+    ports:
+      - 5500:5500
+    command: --marytts-url http://marytts:59125 --mozillatts-url http://mozillatts:5002
+    tty: true
+  marytts:
+    image: synesthesiam/marytts:5.2
+    tty: true
+  mozillatts:
+    image: synesthesiam/mozilla-tts
+    tty: true

--- a/examples/docker-compose-opentts-no-espeak.yml
+++ b/examples/docker-compose-opentts-no-espeak.yml
@@ -1,0 +1,13 @@
+version: '3.3'
+
+services:
+  opentts:
+    image: 'synesthesiam/opentts:en'
+    container_name: opentts
+    ports:
+        - '5500:5500'
+    command: '--no-espeak'
+    restart: unless-stopped
+    logging:
+      options:
+        max-size: 10m

--- a/examples/docker-compose-opentts.yml
+++ b/examples/docker-compose-opentts.yml
@@ -1,0 +1,7 @@
+version: '3.3'
+
+services:
+  opentts:
+    image: synesthesiam/opentts
+    ports:
+      - 5500:5500


### PR DESCRIPTION
Add docker-compose examples to repo, with the files being stored in a new `examples/` directory.
- `docker-compose-opentts.yml` (source from https://rhasspy.readthedocs.io/en/latest/text-to-speech/#opentts)
- `docker-compose-opentts-no-espeak.yml` (source from https://github.com/synesthesiam/opentts#running)
- `docker-compose-opentts-full-suite.yml` (source from https://rhasspy.readthedocs.io/en/latest/text-to-speech/#opentts)