### PR TITLE
Fix Jinja2 version to below 3.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ hypercorn~=0.11.0
 quart~=0.15.0
 quart-cors~=0.5.0
 swagger-ui-py~=21.9.28
+jinja2<3.1.0


### PR DESCRIPTION
Fix for https://github.com/synesthesiam/opentts/issues/33

Confirmed to work on Pop OS! (Ubuntu 22.04) amd64